### PR TITLE
Add support for :namespaced auto-register strategy

### DIFF
--- a/lib/dry/rails/auto_registrar_strategies.rb
+++ b/lib/dry/rails/auto_registrar_strategies.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require 'dry/system/auto_registrar'
+
+require 'dry/rails/loaders'
+
+module Dry
+  module Rails
+    module AutoRegistrarStrategies
+      class Namespaced < Dry::System::AutoRegistrar
+        def component(path, **options)
+          super(path, **options, loader: Loaders::Namespaced)
+        end
+      end
+    end
+  end
+end

--- a/lib/dry/rails/errors.rb
+++ b/lib/dry/rails/errors.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module Dry
+  module Rails
+    InvalidAutoRegistrarStrategy = Class.new(StandardError) do
+      def initialize(name, valid_names)
+        super(<<~STR)
+          AutoRegistrar strategy #{name} is not valid.
+          Possible options are: #{valid_names.inspect}
+        STR
+      end
+    end
+  end
+end

--- a/lib/dry/rails/loaders.rb
+++ b/lib/dry/rails/loaders.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require 'dry/system/loader'
+
+module Dry
+  module Rails
+    # Customized Container class for Rails application
+    #
+    # @api public
+    module Loaders
+      class Namespaced < Dry::System::Loader
+        def path
+          "#{namespace_path}/#{super}"
+        end
+
+        def namespace_path
+          Dry::Rails::Railtie.instance.name
+        end
+      end
+    end
+  end
+end

--- a/spec/dummy/app/services/github.rb
+++ b/spec/dummy/app/services/github.rb
@@ -1,0 +1,6 @@
+module Dummy
+  module Services
+    class Github
+    end
+  end
+end

--- a/spec/integration/auto_register/namespaced_spec.rb
+++ b/spec/integration/auto_register/namespaced_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+RSpec.describe Dry::Rails::Container, '.auto_register!' do
+  subject(:system) { Dummy::Container }
+
+  context 'when :namespaced strategy is used' do
+    before do
+      Dry::Rails.container do
+        configure do |config|
+          config.default_namespace = :dummy
+        end
+
+        auto_register!('app/services', strategy: :namespaced)
+      end
+
+      Dry::Rails::Railtie.reload
+    end
+
+    it 'auto-registers components and uses the app namespace' do
+      expect(system['services.github']).to be_instance_of(Dummy::Services::Github)
+    end
+  end
+end

--- a/spec/integration/container_spec.rb
+++ b/spec/integration/container_spec.rb
@@ -28,5 +28,21 @@ RSpec.describe 'Application container' do
       expect(Dummy::Container['workers.mailer_worker']).to be(mailer_worker) # memoized
       expect(mailer_worker.mailer).to be_instance_of(Mailer)
     end
+
+    context 'strategies' do
+      before do
+        Dry::Rails.container { auto_register!('foo', strategy: :not_here) }
+      end
+
+      after do
+        Dry::Rails.instance_variable_set('@_container_blocks', [])
+      end
+
+      it 'raises a meaningful error when invalid name was passed' do
+        expect {
+          Dry::Rails::Railtie.reload
+        }.to raise_error(Dry::Rails::InvalidAutoRegistrarStrategy, /not_here/)
+      end
+    end
   end
 end


### PR DESCRIPTION
This adds support for an auto-registration strategy which enables you to do the following:

```ruby
Dry::Rails.container do
  config.default_namespace = :my_app

  auto_register!("app/services", strategy: :namespaced)
end

# assuming there's a file `app/services/github.rb` that looks like this:
module MyApp
  module Services
    class Github
    end
  end
end

# then it will be resolved and instantiated just fine via:
MyApp::Container["services.github"]
```

This is cool because:

1) you can use a standard Rails dir/file structure in `app/*`
2) yet you can use namespaces like you should
3) you can organize your codebase in a very elegant way w/o deeply nested dirs like `app/things/my_app/things` (because that's how it would have to look like using the default strategy)

