### PR TITLE
Add ApplicationContract abstract class

### DIFF
--- a/changelog.yml
+++ b/changelog.yml
@@ -1,14 +1,9 @@
 ---
 - version: unreleased
   summary: Initial port of dry-system-rails with a couple of new features
-  date: 
-  fixed: 
-  added: &1
+  date:
+  added:
+  - "Support for ApplicationContract which is automatically defined within the application namespace and configured to work with I18n (@solnic)"
   - "`:namespaced` auto-register strategy which supports loading components from the
     typical Rails directory structure but with the assumption that they are properly
-    namespaced, ie: `app/services/github.rb` => `YourApp::Services::Github`"
-  changed: 
-- version: unreleased
-  date: 
-  summary: Initial port of dry-system-rails with a couple of new features
-  added: *1
+    namespaced, ie: `app/services/github.rb` => `YourApp::Services::Github` (@solnic)"

--- a/lib/dry/rails/container.rb
+++ b/lib/dry/rails/container.rb
@@ -5,6 +5,9 @@ require 'dry/system/container'
 require 'dry/rails/errors'
 require 'dry/rails/auto_registrar_strategies'
 
+require 'dry/rails/feature'
+require 'dry/rails/features/application_contract'
+
 module Dry
   module Rails
     # Customized Container class for Rails application
@@ -12,6 +15,7 @@ module Dry
     # @api public
     class Container < System::Container
       setting :auto_register_configs, [], &:dup
+      setting :features, %i[application_contract]
 
       AUTO_REGISTER_STRATEGIES = {
         default: -> system { system.config.auto_registrar },
@@ -30,6 +34,11 @@ module Dry
           end
 
           self
+        end
+
+        # @api private
+        def features
+          @features ||= config.features.map { |name| Feature[name] }
         end
 
         # @api private

--- a/lib/dry/rails/core/application_contract.rb
+++ b/lib/dry/rails/core/application_contract.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require 'dry/validation/contract'
+
+module Dry
+  module Rails
+    module Core
+      class ApplicationContract < Dry::Validation::Contract
+        # @api private
+        def self.finalize!(railtie)
+          load_paths = Dir[railtie.container.root.join('config/locales/*.yml')]
+
+          config.messages.top_namespace = :contracts
+          config.messages.backend = :i18n
+          config.messages.load_paths += load_paths
+
+          self
+        end
+      end
+    end
+  end
+end

--- a/lib/dry/rails/feature.rb
+++ b/lib/dry/rails/feature.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module Dry
+  module Rails
+    # @api private
+    class Feature
+      # @api private
+      attr_reader :name
+
+      # @api private
+      def self.[](name)
+        klass = Features.const_get(name.to_s.classify)
+        klass.new(name)
+      end
+
+      # @api private
+      def initialize(name)
+        @name = name
+      end
+
+      # @api private
+      def enable!(railtie)
+        raise NotImplementedError
+      end
+    end
+  end
+end

--- a/lib/dry/rails/features/application_contract.rb
+++ b/lib/dry/rails/features/application_contract.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require 'dry/rails/feature'
+require 'dry/rails/core/application_contract'
+
+module Dry
+  module Rails
+    module Features
+      # @api private
+      class ApplicationContract < Feature
+        # @api private
+        def enable!(railtie)
+          railtie.set_or_reload(
+            :ApplicationContract, create_class.finalize!(railtie)
+          )
+        end
+
+        # @api private
+        def create_class
+          Class.new(Core::ApplicationContract)
+        end
+      end
+    end
+  end
+end

--- a/lib/dry/rails/railtie.rb
+++ b/lib/dry/rails/railtie.rb
@@ -2,8 +2,6 @@
 
 require 'rails/railtie'
 
-require 'dry/rails/core/application_contract'
-
 module Dry
   module Rails
     # System railtie is responsible for setting up a container and handling reloading in dev mode
@@ -21,10 +19,9 @@ module Dry
         set_or_reload(:Container, container)
         set_or_reload(:Import, container.injector)
 
-        # TODO: this should not be hardcoded here
-        set_or_reload(
-          :ApplicationContract, Class.new(Core::ApplicationContract).finalize!(self)
-        )
+        container.features.each do |feature|
+          feature.enable!(self)
+        end
 
         container.refresh_boot_files if reloading?
 

--- a/lib/dry/rails/railtie.rb
+++ b/lib/dry/rails/railtie.rb
@@ -2,6 +2,8 @@
 
 require 'rails/railtie'
 
+require 'dry/rails/core/application_contract'
+
 module Dry
   module Rails
     # System railtie is responsible for setting up a container and handling reloading in dev mode
@@ -19,11 +21,21 @@ module Dry
         set_or_reload(:Container, container)
         set_or_reload(:Import, container.injector)
 
+        # TODO: this should not be hardcoded here
+        set_or_reload(
+          :ApplicationContract, Class.new(Core::ApplicationContract).finalize!(self)
+        )
+
         container.refresh_boot_files if reloading?
 
         container.finalize!(freeze: !::Rails.env.test?)
       end
       alias_method :reload, :finalize!
+
+      # @api private
+      def container
+        app_namespace::Container
+      end
 
       # @api private
       def reloading?

--- a/lib/dry/rails/railtie.rb
+++ b/lib/dry/rails/railtie.rb
@@ -16,6 +16,8 @@ module Dry
       def finalize!
         container = Dry::Rails.create_container(name: name)
 
+        remove_constants
+
         set_or_reload(:Container, container)
         set_or_reload(:Import, container.injector)
 
@@ -64,6 +66,13 @@ module Dry
         end
 
         app_namespace.const_set(const_name, const)
+      end
+
+      # @api private
+      def remove_constants
+        (app_namespace.constants - %i[Container Import]).each do |const_name|
+          app_namespace.__send__(:remove_const, const_name)
+        end
       end
     end
   end

--- a/spec/dummy/config/locales/en.yml
+++ b/spec/dummy/config/locales/en.yml
@@ -1,23 +1,4 @@
-# Files in the config/locales directory are used for internationalization
-# and are automatically loaded by Rails. If you want to use locales other
-# than English, add the necessary files in this directory.
-#
-# To use the locales, use `I18n.t`:
-#
-#     I18n.t 'hello'
-#
-# In views, this is aliased to just `t`:
-#
-#     <%= t('hello') %>
-#
-# To use a different locale, set it with `I18n.locale`:
-#
-#     I18n.locale = :es
-#
-# This would use the information in config/locales/es.yml.
-#
-# To learn more, please read the Rails Internationalization guide
-# available at http://guides.rubyonrails.org/i18n.html.
-
 en:
-  hello: "Hello world"
+  contracts:
+    errors:
+      filled?: 'cannot be blank'

--- a/spec/dummy/config/locales/pl.yml
+++ b/spec/dummy/config/locales/pl.yml
@@ -1,0 +1,4 @@
+pl:
+  contracts:
+    errors:
+      filled?: 'nie może być puste'

--- a/spec/integration/dry/rails/container/application_contract_spec.rb
+++ b/spec/integration/dry/rails/container/application_contract_spec.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+RSpec.describe Dry::Rails::Core::ApplicationContract do
+  subject(:contract) do
+    Class.new(Dummy::ApplicationContract) do
+      schema do
+        required(:name).filled(:string)
+      end
+    end.new
+  end
+
+  it 'preconfigures subclasses to use localized messages' do
+    I18n.with_locale(:en) do
+      expect(contract.(name: '').errors[:name])
+        .to eql(['cannot be blank'])
+    end
+  end
+
+  it 'enables all locales via I18n' do
+    I18n.with_locale(:pl) do
+      expect(contract.(name: '').errors[:name]).to eql(['nie może być puste'])
+    end
+  end
+end

--- a/spec/integration/dry/rails/container/application_contract_spec.rb
+++ b/spec/integration/dry/rails/container/application_contract_spec.rb
@@ -1,24 +1,44 @@
 # frozen_string_literal: true
 
 RSpec.describe Dry::Rails::Core::ApplicationContract do
-  subject(:contract) do
-    Class.new(Dummy::ApplicationContract) do
-      schema do
-        required(:name).filled(:string)
-      end
-    end.new
-  end
+  context 'when the feature is enabled' do
+    subject(:contract) do
+      Class.new(Dummy::ApplicationContract) do
+        schema do
+          required(:name).filled(:string)
+        end
+      end.new
+    end
 
-  it 'preconfigures subclasses to use localized messages' do
-    I18n.with_locale(:en) do
-      expect(contract.(name: '').errors[:name])
-        .to eql(['cannot be blank'])
+    it 'preconfigures subclasses to use localized messages' do
+      I18n.with_locale(:en) do
+        expect(contract.(name: '').errors[:name])
+          .to eql(['cannot be blank'])
+      end
+    end
+
+    it 'enables all locales via I18n' do
+      I18n.with_locale(:pl) do
+        expect(contract.(name: '').errors[:name]).to eql(['nie może być puste'])
+      end
     end
   end
 
-  it 'enables all locales via I18n' do
-    I18n.with_locale(:pl) do
-      expect(contract.(name: '').errors[:name]).to eql(['nie może być puste'])
+  context 'when the feature is disabled' do
+    before(:all) do
+      Dry::Rails.container do
+        config.features = []
+      end
+    end
+
+    after(:all) do
+      Dry::Rails.container do
+        config.features = config.pristine.features
+      end
+    end
+
+    it 'does not define the contract class' do
+      expect(Dummy.const_defined?(:ApplicationContract)).to be(false)
     end
   end
 end


### PR DESCRIPTION
This adds `ApplicationContract` that's enabled by default. This abstract class that your contracts can inherit from is pre-configured to work with `config/locales/*.yml`, your custom message translations should be placed under `contracts` namespace.

A real-world usage can look like this:

```ruby
# config/initializers/system.rb
Dry::Rails.container do
  auto_register!("app/contracts", strategy: :namespaced)
end

# app/contracts/new_user.rb"
class Dummy::Contracts::NewUser < ApplicationContract
  params do
    required(:name).filled(:string)
    required(:email).filled(:string)
  end
end
```

### TODO

- [x] define add `app_namespace::ApplicationContract` automatically
- [x] add support for all available locales
- [x] add a mechanism for loading "features" based on a configuration, so that users can enable/disable certain "features"