### PR TITLE
Feature/safe params

### DIFF
--- a/lib/dry/rails/boot/safe_params.rb
+++ b/lib/dry/rails/boot/safe_params.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+Dry::System.register_component(:safe_params, provider: :rails) do
+  init do
+    require 'dry/rails/core/safe_params'
+  end
+
+  start do
+    ApplicationController.include(Dry::Rails::Core::SafeParams)
+  end
+end

--- a/lib/dry/rails/container.rb
+++ b/lib/dry/rails/container.rb
@@ -13,7 +13,7 @@ module Dry
     # @api public
     class Container < System::Container
       setting :auto_register_configs, [], &:dup
-      setting :features, %i[application_contract], reader: true
+      setting :features, %i[application_contract safe_params], reader: true
 
       AUTO_REGISTER_STRATEGIES = {
         default: -> system { system.config.auto_registrar },

--- a/lib/dry/rails/core/safe_params.rb
+++ b/lib/dry/rails/core/safe_params.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+require 'dry/schema/params'
+
+module Dry
+  module Rails
+    module Core
+      # SafeParams controller feature
+      #
+      # @api public
+      module SafeParams
+        # @api private
+        def self.included(klass)
+          super
+          klass.extend(ClassMethods)
+        end
+
+        module ClassMethods
+          # Define a schema for controller action(s)
+          #
+          # @param [Array<Symbol>] *actions
+          #
+          # @api public
+          def schema(*actions, &block)
+            schema = Dry::Schema.Params(&block)
+
+            actions.each do |name|
+              schemas[name] = schema
+            end
+
+            before_action(:set_safe_params, only: actions)
+
+            self
+          end
+
+          # Return registered schemas
+          #
+          # @api private
+          def schemas
+            @schemas ||= {}
+          end
+        end
+
+        # Return schema result
+        #
+        # @param [Dry::Schema::Result]
+        #
+        # @api public
+        def safe_params
+          @safe_params
+        end
+
+        # Return registered action schemas
+        #
+        # @return [Hash<Symbol => Dry::Schema::Params]
+        #
+        # @api public
+        def schemas
+          self.class.schemas
+        end
+
+        private
+
+        # @api private
+        def set_safe_params
+          @safe_params = schemas[action_name.to_sym].(request.params)
+        end
+      end
+    end
+  end
+end

--- a/spec/dummy/app/controllers/users_controller.rb
+++ b/spec/dummy/app/controllers/users_controller.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class UsersController < ApplicationController
+  schema(:show) do
+    required(:id).value(:integer)
+  end
+
+  def show
+    if safe_params.success?
+      render json: { id: safe_params[:id], name: 'Jane' }
+    else
+      render json: { errors: safe_params.errors.to_h }
+    end
+  end
+end

--- a/spec/dummy/config/routes.rb
+++ b/spec/dummy/config/routes.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 Rails.application.routes.draw do
-  # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
+  get 'users/show/:id' => 'users#show'
 end

--- a/spec/integration/dry/rails/container/safe_params_spec.rb
+++ b/spec/integration/dry/rails/container/safe_params_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+RSpec.describe Dry::Rails::Core::SafeParams do
+  subject(:controller) do
+    ApplicationController.new
+  end
+
+  describe '.schema' do
+    before do
+      ApplicationController.schema(:show, :edit) do
+        required(:id).filled(:integer)
+      end
+    end
+
+    it 'defines a schema for specific actions' do
+      %i[show edit].each do |action|
+        expect(controller.schemas[action].(id: '1')).to be_success
+        expect(controller.schemas[action].(id: 'foo')).to be_failure
+      end
+    end
+  end
+end

--- a/spec/requests/users_spec.rb
+++ b/spec/requests/users_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+RSpec.describe 'UsersController', type: :request do
+  describe 'GET /users/show' do
+    it 'returns a successful response' do
+      get '/users/show/312'
+
+      json = JSON.parse(response.body, symbolize_names: true)
+
+      expect(json[:id]).to be(312)
+      expect(json[:name]).to eql('Jane')
+    end
+
+    it 'returns errors' do
+      get '/users/show/oops'
+
+      json = JSON.parse(response.body, symbolize_names: true)
+
+      expect(json[:errors]).to eql(id: ['must be an integer'])
+    end
+  end
+end


### PR DESCRIPTION
This adds `:safe_params` feature, enabled by default. This adds a small DSL to `ApplicationController` for defining action params schemas, powered by dry-schema. This is a much more powerful alternative to `strong_parameters`.

⚠️ Notice that **this is not an alternative to Model validation**. It is an alternative to **strong_parameters** ⚠️ 

We can combine this with validation contracts though, but that will come later.

Here's an example:

```ruby
class UsersController < ApplicationController
  schema(:show) do
    required(:id).value(:integer)
  end

  def show
    if safe_params.success?
      render json: { id: safe_params[:id], name: 'Jane' }
    else
      render json: { errors: safe_params.errors.to_h }
    end
  end
end
```

This is very basic, even though the schemas are very powerful, but from result-handling point of view we're not doing much yet.

In the near future we can easily add things like automatic failure handling based on configuration etc.