### PR TITLE
Add application template

### DIFF
--- a/dry-rails.gemspec
+++ b/dry-rails.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |spec|
   spec.summary       = "The official dry-rb railtie for Ruby on Rails"
   spec.description   = "dry-rails provides the official integration of dry-rb gems with Ruby on Rails framework."
   spec.homepage      = 'https://dry-rb.org/gems/dry-rails'
-  spec.files         = Dir["CHANGELOG.md", "LICENSE", "README.md", "dry-rails.gemspec", "lib/**/*"]
+  spec.files         = Dir["CHANGELOG.md", "LICENSE", "README.md", "dry-rails.gemspec", "template.rb", "lib/**/*"]
   spec.bindir        = 'bin'
   spec.executables   = []
   spec.require_paths = ['lib']

--- a/template.rb
+++ b/template.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+gem 'dry-rails', github: 'dry-rb/dry-rails'
+
+initializer 'system.rb', <<-CODE
+  Dry::Rails.container do
+    # cherry-pick features
+    config.features = %i[application_contract]
+
+    # enable auto-registration in the lib dir
+    # config.auto_register << 'lib'
+
+    # enable auto-registration of custom components
+    # auto_register!('app/serializers', strategy: :namespaced)
+  end
+CODE


### PR DESCRIPTION
Closes #5 

@solnic Here's the PR as discussed in the issue. As the template has nothing to do with the gem's functionality per se I just put it in the root. The PR allows edits from maintainers in case you want to move it.

