### PR TITLE
Load Container and Import before running initializer

### DIFF
--- a/lib/dry/rails.rb
+++ b/lib/dry/rails.rb
@@ -41,11 +41,14 @@ module Dry
 
       container.config.update(default_options.merge(options))
 
+      container
+    end
+
+    # @api private
+    def self.evaluate_initializer(container)
       _container_blocks.each do |block|
         container.class_eval(&block)
       end
-
-      container
     end
 
     # @api private

--- a/lib/dry/rails/railtie.rb
+++ b/lib/dry/rails/railtie.rb
@@ -23,6 +23,8 @@ module Dry
         set_or_reload(:Container, container)
         set_or_reload(:Import, container.injector)
 
+        Dry::Rails.evaluate_initializer(container)
+
         container.features.each do |feature|
           container.boot(feature, from: :rails)
         end

--- a/spec/dummy/lib/dummy/notifier.rb
+++ b/spec/dummy/lib/dummy/notifier.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module Dummy
+  class Notifier
+    include Import[:mailer]
+  end
+end

--- a/spec/integration/dry/rails/container/resolve_spec.rb
+++ b/spec/integration/dry/rails/container/resolve_spec.rb
@@ -14,4 +14,13 @@ RSpec.describe Dry::Rails::Container, ".[]" do
       expect(system["create_user"]).to be_instance_of(CreateUser)
     end
   end
+
+  context "with auto-registration from system initializer" do
+    it "returns auto-registered component with another auto-injected" do
+      notifier = system['dummy.notifier']
+
+      expect(notifier).to be_instance_of(Dummy::Notifier)
+      expect(notifier.mailer).to be_instance_of(Mailer)
+    end
+  end
 end


### PR DESCRIPTION
This makes `Container` and `Import` available *before* loading system initializer. Otherwise the initializer would fail while trying to load components that needed container and/or import module.