### PR TITLE
Define default_namespace automatically

### DIFF
--- a/lib/dry/rails/railtie.rb
+++ b/lib/dry/rails/railtie.rb
@@ -16,7 +16,7 @@ module Dry
       def finalize!
         stop_features if reloading?
 
-        container = Dry::Rails.create_container(name: name)
+        container = Dry::Rails.create_container(name: name, default_namespace: name.to_s)
 
         container.register(:railtie, self)
 

--- a/spec/integration/dry/rails/container/resolve_spec.rb
+++ b/spec/integration/dry/rails/container/resolve_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe Dry::Rails::Container, ".[]" do
 
   context "with auto-registration from system initializer" do
     it "returns auto-registered component with another auto-injected" do
-      notifier = system['dummy.notifier']
+      notifier = system[:notifier]
 
       expect(notifier).to be_instance_of(Dummy::Notifier)
       expect(notifier.mailer).to be_instance_of(Mailer)


### PR DESCRIPTION
This sets `config.default_namespace` automatically to the lower-cased application constant. ie if your application namespace is `MyApp` then it will be set to `"my_app"`. This setting allows you to omit the namespace when using import module ie:

```ruby
class Notifier
  # instead of this
  include Import["my_app.mailer"]

  # you can do this
  include Import[:mailer]
end
```