### PR TITLE
Allow multiple paths in auto_register!

### DIFF
--- a/lib/dry/rails/container.rb
+++ b/lib/dry/rails/container.rb
@@ -17,10 +17,14 @@ module Dry
       config.auto_registrar = Rails::AutoRegistrars::App
 
       class << self
+        # TODO: this could be moved to dry-system and use a kwarg ie
+        #       `load_paths: (true|false)` because sometimes you want
+        #       them to be auto-set and sometimes you don't
+        #
         # @api public
-        def auto_register!(*args, &block)
-          load_paths!(*args)
-          super
+        def auto_register!(*paths, &block)
+          load_paths!(*paths)
+          paths.each { |path| super(path, &block) }
           self
         end
 
@@ -33,9 +37,11 @@ module Dry
           booter.booted.map(&:identifier).include?(name)
         end
 
-        # @api private
-        def require_path(path)
-          ::Kernel.require(path)
+        if Rails::VERSION.start_with?("5")
+          # @api private
+          def require_path(path)
+            require_dependency(path)
+          end
         end
 
         # This is called when reloading in dev mode

--- a/spec/dummy/app/services/github.rb
+++ b/spec/dummy/app/services/github.rb
@@ -1,8 +1,4 @@
 # frozen_string_literal: true
 
-module Dummy
-  module Services
-    class Github
-    end
-  end
+class Github
 end

--- a/spec/integration/dry/rails/container/auto_register/with_block_spec.rb
+++ b/spec/integration/dry/rails/container/auto_register/with_block_spec.rb
@@ -5,8 +5,6 @@ RSpec.describe Dry::Rails::Container, ".auto_register!" do
 
   before(:all) do
     Dry::Rails.container do
-      auto_register!("lib")
-
       auto_register!("app/workers") do |config|
         config.memoize = true
       end

--- a/spec/integration/dry/rails/container/auto_register/without_block_spec.rb
+++ b/spec/integration/dry/rails/container/auto_register/without_block_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+RSpec.describe Dry::Rails::Container, ".auto_register!" do
+  subject(:system) { Dummy::Container }
+
+  context "with a single path" do
+    before(:all) do
+      Dry::Rails.container do
+        auto_register!("app/operations")
+      end
+    end
+
+    it "auto-registers files found under the specified path" do
+      create_user = Dummy::Container["create_user"]
+
+      expect(create_user).to be_instance_of(CreateUser)
+    end
+  end
+
+  context "with multiple paths" do
+    before(:all) do
+      Dry::Rails.container do
+        auto_register!("app/operations", "app/services")
+      end
+    end
+
+    it "auto-registers files found under the specified paths" do
+      create_user = Dummy::Container["create_user"]
+      github = Dummy::Container["github"]
+
+      expect(create_user).to be_instance_of(CreateUser)
+      expect(github).to be_instance_of(Github)
+    end
+  end
+end


### PR DESCRIPTION
This extends `auto_register!` so that it can work with multiple paths like so:

```ruby
# config/initializers/system.rb
Dry::Rails.container do
  auto_register!("app/operations", "app/workers")
end
```