### PR TITLE
Add controller_helpers feature

### DIFF
--- a/lib/dry/rails/boot/controller_helpers.rb
+++ b/lib/dry/rails/boot/controller_helpers.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+Dry::System.register_component(:controller_helpers, provider: :rails) do
+  init do
+    require "dry/rails/core/controller_helpers"
+  end
+
+  start do
+    ApplicationController.include(Dry::Rails::Core::ControllerHelpers)
+  end
+end

--- a/lib/dry/rails/container.rb
+++ b/lib/dry/rails/container.rb
@@ -12,7 +12,7 @@ module Dry
     #
     # @api public
     class Container < System::Container
-      setting :features, %i[application_contract safe_params], reader: true
+      setting :features, %i[application_contract safe_params controller_helpers], reader: true
 
       config.auto_registrar = Rails::AutoRegistrars::App
 

--- a/lib/dry/rails/core/controller_helpers.rb
+++ b/lib/dry/rails/core/controller_helpers.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+module Dry
+  module Rails
+    module Core
+      # Controller helpers
+      #
+      # @api public
+      module ControllerHelpers
+        # Return a component from the application container
+        #
+        # @example
+        #   def index
+        #     users = resolve("users.index").(safe_params[:query])
+        #     render json: users
+        #   end
+        #
+        # @param [Symbol, String]
+        #
+        # @return [Object]
+        #
+        # @api public
+        def resolve(key)
+          container[key]
+        end
+
+        # Return the application container
+        #
+        # @return [Dry::Rails::Container]
+        #
+        # @api public
+        def container
+          Railtie.container
+        end
+      end
+    end
+  end
+end

--- a/spec/integration/dry/rails/container/controller_helpers_spec.rb
+++ b/spec/integration/dry/rails/container/controller_helpers_spec.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+RSpec.describe Dry::Rails::Core::SafeParams do
+  subject(:controller) do
+    ApplicationController.new
+  end
+
+  describe "#resolve" do
+    it "resolves container component" do
+      expect(controller.resolve(:mailer)).to be_instance_of(Mailer)
+    end
+  end
+end


### PR DESCRIPTION
This adds a new feature called `:controller_helpers`. For now it will only provide `resolve` and `controller` shortcut methods.