### PR TITLE
Set up default inflector to be ActiveSupport::Inflector

### DIFF
--- a/lib/dry/rails/railtie.rb
+++ b/lib/dry/rails/railtie.rb
@@ -22,10 +22,12 @@ module Dry
           root: root_path,
           name: name,
           default_namespace: name.to_s,
+          inflector: default_inflector,
           system_dir: root_path.join("config/system")
         )
 
         container.register(:railtie, self)
+        container.register(:inflector, default_inflector)
 
         set_or_reload(:Container, container)
         set_or_reload(:Import, container.injector)
@@ -75,6 +77,11 @@ module Dry
           top_level_namespace = ::Rails.application.class.to_s.split("::").first
           Object.const_get(top_level_namespace)
         end
+      end
+
+      # @api private
+      def default_inflector
+        ActiveSupport::Inflector
       end
 
       # @api private

--- a/spec/integration/dry/rails/container_spec.rb
+++ b/spec/integration/dry/rails/container_spec.rb
@@ -1,24 +1,20 @@
 # frozen_string_literal: true
 
+require "logger"
+
 RSpec.describe Dry::Rails, ".container" do
   subject(:system) { Dummy::Container }
 
   before do
     Dry::Rails.container do
-      configure do |config|
-        config.default_namespace = :dummy
-      end
-    end
-
-    Dry::Rails.container do
-      register(:inflector, Dry::Inflector.new)
+      register(:logger, Logger.new($stdout))
     end
 
     Dry::Rails::Railtie.reload
   end
 
   it "allows setting up the container in multiple steps" do
-    expect(system.config.default_namespace).to be(:dummy)
-    expect(system[:inflector]).to be_instance_of(Dry::Inflector)
+    expect(system.config.default_namespace).to eql("dummy")
+    expect(system[:logger]).to be_instance_of(Logger)
   end
 end

--- a/spec/integration/dry/rails/railtie/inflector_spec.rb
+++ b/spec/integration/dry/rails/railtie/inflector_spec.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+RSpec.describe Dry::Rails::Railtie, "inflector" do
+  it "sets up ActiveSupport::Inflector by default" do
+    expect(Dummy::Container[:inflector]).to be(ActiveSupport::Inflector)
+  end
+end


### PR DESCRIPTION
This sets up `ActiveSupport::Inflector` as the default inflector and *exposes* it via the container too. This makes sense because we want to inject inflectors as dependencies too, rather than referring to global constants. This gives more flexibility, which can be really useful ie when you need customized inflections just in one part of the app (yes, it can happen).