### PR TITLE
Dynamic lookup without ancestors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,4 +8,5 @@ tmp/
 Gemfile.lock
 .byebug_history
 spec/dummy/.bundle
+spec/**/log/*.log
 doc

--- a/lib/dry/rails/railtie.rb
+++ b/lib/dry/rails/railtie.rb
@@ -70,14 +70,14 @@ module Dry
       #
       # @api public
       def container
-        app_namespace.const_get(:Container)
+        app_namespace.const_get(:Container, false)
       end
 
       # Return true if we're in code-reloading mode
       #
       # @api private
       def reloading?
-        app_namespace.const_defined?(:Container)
+        app_namespace.const_defined?(:Container, false)
       end
 
       # Return the default system name
@@ -118,7 +118,7 @@ module Dry
 
       # @api private
       def set_or_reload(const_name, const)
-        if app_namespace.const_defined?(const_name)
+        if app_namespace.const_defined?(const_name, false)
           app_namespace.__send__(:remove_const, const_name)
         end
 

--- a/spec/dummy/app/models/container.rb
+++ b/spec/dummy/app/models/container.rb
@@ -1,0 +1,1 @@
+class Container; end


### PR DESCRIPTION
`MyApp.const_get(:Container)` will return both `MyApp::Container` and
just `Container` which might easily confict with existing classes. Set
`inherit` flag to `false` to prevent this.