### PR TITLE
[safe_params] ensure the hook is prepended (required in rails 5.x)

### DIFF
--- a/lib/dry/rails/features/safe_params.rb
+++ b/lib/dry/rails/features/safe_params.rb
@@ -15,7 +15,7 @@ module Dry
           klass.extend(ClassMethods)
 
           klass.class_eval do
-            before_action(:set_safe_params)
+            before_action(:set_safe_params, prepend: true)
           end
         end
 


### PR DESCRIPTION
Refs #26