### PR TITLE
Require dry-system 0.18.1; configure bootable_dirs

### DIFF
--- a/dry-rails.gemspec
+++ b/dry-rails.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |spec|
 
   # to update dependencies edit project.yml
   spec.add_runtime_dependency "dry-schema", "~> 1.5"
-  spec.add_runtime_dependency "dry-system", "~> 0.17.0"
+  spec.add_runtime_dependency "dry-system", "~> 0.18.0", ">= 0.18.1"
   spec.add_runtime_dependency "dry-validation", "~> 1.5"
 
   spec.add_development_dependency "bundler"

--- a/lib/dry/rails/railtie.rb
+++ b/lib/dry/rails/railtie.rb
@@ -32,7 +32,8 @@ module Dry
           name: name,
           default_namespace: name.to_s,
           inflector: default_inflector,
-          system_dir: root_path.join("config/system")
+          system_dir: root_path.join("config/system"),
+          bootable_dirs: [root_path.join("config/system/boot")]
         )
 
         # Enable :env plugin by default because it is a very common requirement

--- a/project.yml
+++ b/project.yml
@@ -11,6 +11,6 @@ gemspec:
     - rake
     - rspec
   runtime_dependencies:
-    - [dry-system, "~> 0.17.0"]
+    - [dry-system, "~> 0.18.0", ">= 0.18.1"]
     - [dry-schema, "~> 1.5"]
     - [dry-validation, "~> 1.5"]


### PR DESCRIPTION
This retains compatibility with the latest dry-system multiple boot dirs support

Fixes #37