### PR TITLE
Update gem version on docsite

### DIFF
--- a/docsite/source/index.html.md
+++ b/docsite/source/index.html.md
@@ -28,7 +28,7 @@ rails new my_app -MOPCSJT --template https://raw.githubusercontent.com/dry-rb/dr
 If you already have a Rails application, simply add `dry-rails` to your `Gemfile`:
 
 ```ruby
-gem "dry-rails", "~> 0.1"
+gem "dry-rails", "~> 0.3"
 ```
 
 ## Overview


### PR DESCRIPTION
The site still referencing the version `0.1` of the gem and this can lead to confusion to new users. So this pull request updates it to the current version which is `0.3`.