### PR TITLE
Update for latest dry-configurable setting API

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,9 @@ source "https://rubygems.org"
 
 gemspec
 
+gem "dry-configurable", github: "dry-rb/dry-configurable"
+gem "dry-system", github: "dry-rb/dry-system"
+
 eval_gemfile "Gemfile.devtools"
 
 RAILS_VERSION = (ENV["RAILS_VERSION"] || "6.0").sub("x", "0")

--- a/lib/dry/rails/container.rb
+++ b/lib/dry/rails/container.rb
@@ -27,7 +27,7 @@ module Dry
       #
       #   @api public
       # @!scope class
-      setting :features, %i[application_contract safe_params controller_helpers], reader: true
+      setting :features, default: %i[application_contract safe_params controller_helpers], reader: true
 
       # @overload config.auto_register_paths=(paths)
       #   Set an array of path/block pairs for auto-registration
@@ -39,7 +39,7 @@ module Dry
       #
       #   @api public
       # @!scope class
-      setting :auto_register_paths, [].freeze, reader: true
+      setting :auto_register_paths, default: [].freeze, reader: true
 
       # @overload config.auto_inject_constant=(auto_inject_constant)
       #   Set a custom import constant name
@@ -48,7 +48,7 @@ module Dry
       #
       #   @api public
       # @!scope class
-      setting :auto_inject_constant, "Deps", reader: true
+      setting :auto_inject_constant, default: "Deps", reader: true
 
       # @overload config.container_constant=(container_constant)
       #   Set a custom container constant
@@ -57,7 +57,7 @@ module Dry
       #
       #   @api public
       # @!scope class
-      setting :container_constant, "Container", reader: true
+      setting :container_constant, default: "Container", reader: true
 
       # @!endgroup
 


### PR DESCRIPTION
This will need to be handled _after_ the rest of this gem is tested with dry-system 0.19.0, which includes a raft of other breaking changes.

I won't be doing this before the dry-configurable 0.13.0 release, because the dry-system-related changes may take some time, and I don't want to delay the dry-configurable release any longer.

Thanks to the 0.18.2 release of dry-system I made, which includes compatibility fixes to ensure it works with future dry-configurable releases, dry-rails will continue to work too.