### PR TITLE
Fix pending test

### DIFF
--- a/spec/integration/dry/rails/container/start_spec.rb
+++ b/spec/integration/dry/rails/container/start_spec.rb
@@ -1,13 +1,7 @@
 # frozen_string_literal: true
 
-require "user_repo"
-
 RSpec.describe Dry::Rails::Container, ".start" do
   subject(:user_repo) { UserRepo.new }
-
-  before do
-    pending "this fails for some reason" if RUBY_VERSION >= "3.1"
-  end
 
   context "when the system did not start a bootable dep" do
     it "lazy-loads and starts the dep" do


### PR DESCRIPTION
The test was failing due to `UserRepo` supposedly not defined. Removing the require and letting Zeitwerk take care of things fixes it. Not sure why, but perhaps some issue with symlinks.